### PR TITLE
parent.less.php

### DIFF
--- a/plugins/MauticFocusBundle/Views/Builder/Notification/parent.less.php
+++ b/plugins/MauticFocusBundle/Views/Builder/Notification/parent.less.php
@@ -15,49 +15,58 @@
 .mf-notification-iframe {
     position: fixed;
     z-index: 21001;
+    margin-top: -100%;
 
-    &.mf-animate {
-        .notificationAnimate();
-    }
+    &.mf-loaded {
+        margin-top: 0;
+        margin-bottom: 0;
 
-    &.mf-notification-iframe-top-left {
-        top: 5px;
-        left: 5px;
 
         &.mf-animate {
-            .notificationName(mf-notification-slide-right);
+            .notificationAnimate();
+        }
+
+        &.mf-notification-iframe-top-left {
+            top: 5px;
+            left: 5px;
+
+            &.mf-animate {
+                .notificationName(mf-notification-slide-right);
+            }
+        }
+
+        &.mf-notification-iframe-top-right {
+            top: 5px;
+            right: 5px;
+
+            &.mf-animate {
+                .notificationName(mf-notification-slide-left);
+            }
+        }
+
+        &.mf-notification-iframe-bottom-left {
+            bottom: 5px;
+            left: 5px;
+
+            &.mf-animate {
+                .notificationName(mf-notification-slide-right);
+            }
+        }
+
+        &.mf-notification-iframe-bottom-right {
+            bottom: 5px;
+            right: 5px;
+
+            &.mf-animate {
+                .notificationName(mf-notification-slide-left);
+            }
+        }
+
+        &.mf-responsive {
+            left: 0 !important;
+            right: 0 !important;
         }
     }
 
-    &.mf-notification-iframe-top-right {
-        top: 5px;
-        right: 5px;
 
-        &.mf-animate {
-            .notificationName(mf-notification-slide-left);
-        }
-    }
-
-    &.mf-notification-iframe-bottom-left {
-        bottom: 5px;
-        left: 5px;
-
-        &.mf-animate {
-            .notificationName(mf-notification-slide-right);
-        }
-    }
-
-    &.mf-notification-iframe-bottom-right {
-        bottom: 5px;
-        right: 5px;
-
-        &.mf-animate {
-            .notificationName(mf-notification-slide-left);
-        }
-    }
-
-    &.mf-responsive {
-        left: 0 !important;
-        right: 0 !important;
-    }
 }


### PR DESCRIPTION
Fixed an error where the notification modal would load in the top left, then disappear and reload with animation in the correct location.

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: Focus notification had a bug where it would flash onto the screen before reloading correctly. As the behaviour was correct for the modal notification, made changes to the notification/parent.less.php to mimic the behaviour of modal/parent.less.php. The css doesn't fire until mf-loaded class has been added to the iframe now.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a focus notification - best seen when not set to top left. Set animation to on
2. Before this fix, the notification would load in the top left-hand corner, before loading correctly. This fix stops that behaviour.

#### Steps to test this PR:
1. Create a focus notification
2. Confirm that the notification doesn't briefly flash onto the screen.

#### List deprecations along with the new alternative:
1. Old version of parent.less.php for the notification.


#### List backwards compatibility breaks:
1. None known - all notifications will need rebuilding to fix.
